### PR TITLE
Fix setup with gcc 8 or newer

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools.command.build_py import build_py
 class CustomBuildPy(build_py):
 
     def run(self):
-        os.environ["CFLAGS"] = "%s -fPIC" % os.environ.get("CFLAGS", "")
+        os.environ["CFLAGS"] = "%s -fPIC -Werror=format-truncation=0" % os.environ.get("CFLAGS", "")
         subprocess.call("cd papi/src/ && ./configure", shell=True)  # noqa
         subprocess.call("cd papi/src/ && make", shell=True)  # noqa
         build_py.run(self)


### PR DESCRIPTION
Hi,

I was unable to install _PyPAPI_ using _pip3_ or from sources on devices with _gcc 8_ or _gcc 9_. The only place where I got it working was devices with gcc 7.2...

I found out that the internal C _PAPI_ library is compiled with `-Werror` flag and probably the newer _gcc_ introduces some new warnings...

```
gcc  -Wno-override-init -fPIC -g -DSTATIC_PAPI_EVENTS_TABLE -DPEINCLUDE=\"libpfm4/include/perfmon/perf_event.h\" -D_REENTRANT -D_GNU_SOURCE -DUSE_COMPILER_TLS  -Wall -Ilibpfm4/include -fvisibility=hidden -Wextra  -g -Wall -Werror -Wextra -Wno-unused-parameter -I. -I/home/martin/pypapi/papi/src/libpfm4/include -DCONFIG_PFMLIB_DEBUG -DCONFIG_PFMLIB_OS_LINUX  -g -Wall -Werror -Wextra -Wno-unused-parameter -I. -I/home/martin/pypapi/papi/src/libpfm4/lib/../include -DCONFIG_PFMLIB_DEBUG -DCONFIG_PFMLIB_OS_LINUX -D_REENTRANT -I. -fvisibility=hidden -DCONFIG_PFMLIB_ARCH_X86 -DCONFIG_PFMLIB_ARCH_X86_64 -I. -c pfmlib_perf_event_pmu.c
pfmlib_perf_event_pmu.c: In function ‘gen_tracepoint_table’:
pfmlib_perf_event_pmu.c:349:36: error: ‘%s’ directive output may be truncated writing up to 255 bytes into a region of size between 0 and 4095 [-Werror=format-truncation=]
  349 |   snprintf(d2path, MAXPATHLEN, "%s/%s", debugfs_mnt, d1->d_name);
      |                                    ^~
pfmlib_perf_event_pmu.c:349:3: note: ‘snprintf’ output between 2 and 4352 bytes into a destination of size 4096
  349 |   snprintf(d2path, MAXPATHLEN, "%s/%s", debugfs_mnt, d1->d_name);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
pfmlib_perf_event_pmu.c:399:58: error: ‘%s’ directive output may be truncated writing up to 255 bytes into a region of size between 0 and 4095 [-Werror=format-truncation=]
  399 |                         snprintf(idpath, MAXPATHLEN, "%s/%s/id", d2path, d2->d_name);
      |                                                          ^~
pfmlib_perf_event_pmu.c:399:25: note: ‘snprintf’ output between 5 and 4355 bytes into a destination of size 4096
  399 |                         snprintf(idpath, MAXPATHLEN, "%s/%s/id", d2path, d2->d_name);
      |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make[2]: *** [/home/martin/pypapi/papi/src/libpfm4/lib/../rules.mk:30: pfmlib_perf_event_pmu.o] Error 1
make[2]: Leaving directory '/home/martin/pypapi/papi/src/libpfm4/lib'
make[1]: *** [Makefile:52: lib] Error 2
make[1]: Leaving directory '/home/martin/pypapi/papi/src/libpfm4'
make: *** [Rules.pfm4_pe:43: /home/martin/pypapi/papi/src/libpfm4/lib/libpfm.a] Error 2
```

The `-Werror=format-truncation=0` flag solved that issue for me :-) It works fine with _gcc 8_ and _gcc 9_ but I didn't test it with _gcc 7_.